### PR TITLE
get rid of deprecated errors and warnings in Udacity React Nanodegree.

### DIFF
--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -205,11 +205,11 @@ export default class AgendaView extends Component {
     }
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.loadReservations(this.props);
   }
 
-  componentWillReceiveProps(props) {
+  UNSAFE_componentWillReceiveProps(props) {
     if (props.items) {
       this.setState({
         firstResevationLoad: false

--- a/src/agenda/reservation-list/index.js
+++ b/src/agenda/reservation-list/index.js
@@ -1,10 +1,10 @@
 import React, {Component} from 'react';
 import {
-  ListView,
   ActivityIndicator,
   View,
   Text
 } from 'react-native';
+import ListView from 'deprecated-react-native-listview'
 import PropTypes from 'prop-types';
 import XDate from 'xdate';
 
@@ -66,7 +66,7 @@ class ReactComp extends Component {
     this.scrollOver = true;
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.updateDataSource(this.getReservations(this.props).reservations);
   }
 
@@ -91,7 +91,7 @@ class ReactComp extends Component {
     this.updateDataSource(reservations.reservations);
   }
 
-  componentWillReceiveProps(props) {
+  UNSAFE_componentWillReceiveProps(props) {
     if (!dateutils.sameDate(props.topDay, this.props.topDay)) {
       this.setState({
         reservations: []

--- a/src/calendar-list/index.js
+++ b/src/calendar-list/index.js
@@ -1,10 +1,10 @@
 import React, {Component} from 'react';
 import {
-  ListView,
   View,
   Platform,
   Text
 } from 'react-native';
+import ListView from 'deprecated-react-native-listview'
 import PropTypes from 'prop-types';
 import XDate from 'xdate';
 
@@ -126,7 +126,7 @@ class CalendarList extends Component {
     //});
   }
 
-  componentWillReceiveProps(props) {
+  UNSAFE_componentWillReceiveProps(props) {
     const current = parseDate(this.props.current);
     const nextCurrent = parseDate(props.current);
     if (nextCurrent && current && nextCurrent.getTime() !== current.getTime()) {

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -79,7 +79,7 @@ class Calendar extends Component {
     this.shouldComponentUpdate = shouldComponentUpdate;
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const current= parseDate(nextProps.current);
     if (current && current.toString('yyyy MM') !== this.state.currentMonth.toString('yyyy MM')) {
       this.setState({


### PR DESCRIPTION
This nanodegree is outdated and most links are not working. But this part is most broken, students can't follow the udaciFitness project walkthrough because of using deprecated ListView - the app doesn't even load. This is a quick fix, and at least removes errors and warnings and makes it possible to follow the lessons.